### PR TITLE
Updated snipe bot

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,7 +63,7 @@ async def snipe(interaction: discord.Interaction):
         return await interaction.response.send_message("Nothing to snipe")
 
     snipe_em = discord.Embed(description=contents, color=discord.Color.blurple(), timestamp=time)
-    snipe_em.set_author(name=target.display_name, icon_url=target.display_avatar.url)
+    snipe_em.set_author(name=target.name, icon_url=target.display_avatar.url)
 
     if attch: # If an attachment is found (img/video) then it will adjust the embed accordingly.
         if attch[0].proxy_url.endswith('mp4') or attch[0].proxy_url.endswith('mov'):
@@ -87,7 +87,7 @@ async def snipeedit(interaction: discord.Interaction):
         return await interaction.response.send_message("No recent edits found")
 
     snipe_embed = discord.Embed(color=discord.Color.blurple(), timestamp=time)
-    snipe_embed.set_author(name=author.display_name, icon_url=author.display_avatar.url)
+    snipe_embed.set_author(name=author.name, icon_url=author.display_avatar.url)
     snipe_embed.set_footer(text=f"Message edited in {channel}")
 
     # Add fields for original and edited content

--- a/main.py
+++ b/main.py
@@ -21,7 +21,7 @@ sniped_edit = {}
 
 class myBot(commands.Bot): #Being used as an event handler, but this class isn't needed for the bot to work overall (You'd just have to make the necessary changes). It's just more organized.
   async def on_ready(self):
-      print(f"Logged in as {bot.user} (Version: {discord.__version__}") #When the bot is online this function prints.
+      print(f"Logged in as {bot.user} (Version: {discord.__version__})") #When the bot is online this function prints.
 
   async def on_message_delete(self, message):
         if message.author == self.user:
@@ -38,16 +38,13 @@ class myBot(commands.Bot): #Being used as an event handler, but this class isn't
 
 bot = myBot(command_prefix=prefix, intents=intents)
 
-@bot.event
-async def on_ready():
-  print("Bot is up and ready!")
-  try:
+@bot.command()
+@commands.is_owner()
+async def sync_cmds(ctx):
     synced = await bot.tree.sync()
-    print(f"Synced {len(synced)} command(s)") #prints how many commands the bot sees
-  except Exception as e:
-    print(e)   
+    print(f"Synced {len(synced)} command(s)") 
 
-@bot.tree.command(name="snipe", description="will snipe the last message deleted")
+@bot.tree.command(name="snipe", description="will send recently deleted message")
 async def snipe(interaction: discord.Interaction):
   try:
     contents, target, attch, stickers, channel, time = sniped[interaction.channel.id]
@@ -62,7 +59,6 @@ async def snipe(interaction: discord.Interaction):
     attachment = attch[0]
     if attachment.proxy_url.endswith(('mp4', 'mov')):
       attachment_url = attachment.proxy_url
-      snipe_em.description += f"\n Video found! link posted below" #when a video is found it will send this message
     else:
       snipe_em.set_image(url=attachment.proxy_url)
 
@@ -76,7 +72,7 @@ async def snipe(interaction: discord.Interaction):
   if attachment_url:
     await interaction.channel.send(attachment_url)  # Send the video link separately (larger files won't embed but link will still be sent)
 
-@bot.tree.command(name="esnipe", description="will snipe the last message edited")
+@bot.tree.command(name="esnipe", description="will send recently edited message")
 async def snipeedit(interaction: discord.Interaction):
     try:
         original, author, edited, channel, time = sniped_edit[interaction.channel.id]

--- a/main.py
+++ b/main.py
@@ -24,9 +24,8 @@ class myBot(commands.Bot): #Being used as an event handler, but this class isn't
       print(f"Logged in as {bot.user} (Version: {discord.__version__}") #When the bot is online this function prints.
 
   async def on_message_delete(self, message):
-        # Ignore if the message was deleted by the bot itself
         if message.author == self.user:
-            return
+            return # Ignore if the message was deleted by the bot itself
         
         sniped[message.channel.id] = [
             message.content, message.author, message.attachments, message.stickers, message.channel.name, message.created_at
@@ -37,50 +36,45 @@ class myBot(commands.Bot): #Being used as an event handler, but this class isn't
            before.content, before.author, after.content, before.channel.name, before.created_at
 ]
 
-
 bot = myBot(command_prefix=prefix, intents=intents)
-
 
 @bot.event
 async def on_ready():
   print("Bot is up and ready!")
   try:
     synced = await bot.tree.sync()
-    print(f"Synced {len(synced)} command(s)")
+    print(f"Synced {len(synced)} command(s)") #prints how many commands the bot sees
   except Exception as e:
     print(e)   
 
 @bot.tree.command(name="snipe", description="will snipe the last message deleted")
 async def snipe(interaction: discord.Interaction):
   try:
-    contents, target, attch, stickers, channel, time = sniped[
-      interaction.channel.id]
+    contents, target, attch, stickers, channel, time = sniped[interaction.channel.id]
   except KeyError:
     return await interaction.response.send_message("Nothing to snipe")
 
-  snipe_em = discord.Embed(description=contents, color=discord.Color.blurple(), timestamp=time)
-  snipe_em.set_author(name=target.name, icon_url=target.display_avatar.url)
+  snipe_em = discord.Embed(description=contents, color=discord.Color.blurple(), timestamp=time) #this is the embeded message that the bot will send
+  snipe_em.set_author(name=target.name, icon_url=target.display_avatar.url) #change ".name" to "display_name" if you want the bot to show the name and not the discord @
 
   attachment_url = None
   if attch:  # If an attachment is found (img/video) then it will adjust the embed accordingly.
     attachment = attch[0]
     if attachment.proxy_url.endswith(('mp4', 'mov')):
       attachment_url = attachment.proxy_url
-      snipe_em.description += f"\n Video found! link posted below"
+      snipe_em.description += f"\n Video found! link posted below" #when a video is found it will send this message
     else:
       snipe_em.set_image(url=attachment.proxy_url)
 
   if stickers:
     for sticker in stickers:
-      snipe_em.set_image(url=sticker.url)  # sets the embed images as the stickers that were sent
+      snipe_em.set_image(url=sticker.url)  # sets the embed images as the sticker that was sent
 
   snipe_em.set_footer(text=f"Deleted in {channel}")
-  await interaction.response.send_message(
-    embed=snipe_em)  # Send embed with message content and author info
+  await interaction.response.send_message(embed=snipe_em)  # Send embed with message content and author info
 
   if attachment_url:
     await interaction.channel.send(attachment_url)  # Send the video link separately (larger files won't embed but link will still be sent)
-
 
 @bot.tree.command(name="esnipe", description="will snipe the last message edited")
 async def snipeedit(interaction: discord.Interaction):

--- a/main.py
+++ b/main.py
@@ -1,8 +1,6 @@
-#Snipe bot using discord.py 2.0
-
 import discord
 from discord.ext import commands
-
+from time import sleep
 import os
 from dotenv import load_dotenv
 from webserver import keep_alive
@@ -19,67 +17,89 @@ intents.message_content = True
 
 sniped = {}
 sniped_edit = {}
-
 #These dictionaries store the deleted messages that our on_message events capture
-
-
 
 class myBot(commands.Bot): #Being used as an event handler, but this class isn't needed for the bot to work overall (You'd just have to make the necessary changes). It's just more organized.
   async def on_ready(self):
       print(f"Logged in as {bot.user} (Version: {discord.__version__}") #When the bot is online this function prints.
 
-  async def on_message_delete(self, message): #When a message is deleted it looks at the channel that it happened in, the user who deleted it, (along with the other specifications) and appends it to the "sniped" dictionary.
-      sniped[message.channel.id] = [
-          message.content, message.author, message.attachments,
-          message.channel.name, message.created_at
-      ]
+  async def on_message_delete(self, message):
+        # Ignore if the message was deleted by the bot itself
+        if message.author == self.user:
+            return
+        
+        sniped[message.channel.id] = [
+            message.content, message.author, message.attachments, message.stickers,
+            message.channel.name, message.created_at
+        ]
 
-  async def on_message_edit(self, before, after): #Same concept as on_message_delete
-      sniped_edit[before.channel.id] = [
-          before.content, before.author, before.channel.name,
-          before.created_at
-      ]
+  async def on_message_edit(self, before, after):
+        sniped_edit[before.channel.id] = [
+    before.content,
+    before.author,
+    after.content,
+    before.channel.name,
+    before.created_at
+]
 
 
 bot = myBot(command_prefix=prefix, intents=intents)
 
 
-@bot.command()
-async def snipe(ctx):
+@bot.event
+async def on_ready():
+  print("Bot is up and ready!")
+  try:
+    synced = await bot.tree.sync()
+    print(f"Synced {len(synced)} command(s)")
+  except Exception as e:
+    print(e)   
+
+@bot.tree.command(name="snipe", description="will snipe the last message deleted")
+async def snipe(interaction: discord.Interaction):
     try:
-        contents, target, attch, channel, time = sniped[ctx.channel.id]
-    except KeyError: #If no one has deleted a message or the cache is reset, then the bot prints "Nothing to snipe" and stops.
-        return await ctx.send("Nothing to snipe")
+        contents, target, attch, stickers, channel, time = sniped[interaction.channel.id]
+    except KeyError:
+        return await interaction.response.send_message("Nothing to snipe")
 
-    snipe_em = discord.Embed(description=contents,
-                             color=discord.Color.blurple(),
-                             timestamp=time)
-    snipe_em.set_author(name=target, icon_url=target.display_avatar.url)
+    snipe_em = discord.Embed(description=contents, color=discord.Color.blurple(), timestamp=time)
+    snipe_em.set_author(name=target.display_name, icon_url=target.display_avatar.url)
 
-    if attch: #If an attachment is found (img/video) then it will adjust to the embed accordingly.
-        if attch[0].proxy_url.endswith('mp4'):
-            await ctx.send(embed=snipe_em)
-            return await ctx.send(content=attch[0].proxy_url)
+    if attch: # If an attachment is found (img/video) then it will adjust the embed accordingly.
+        if attch[0].proxy_url.endswith('mp4') or attch[0].proxy_url.endswith('mov'):
+            snipe_em.description += f"\nAttachment: {attch[0].proxy_url}"
         else:
             snipe_em.set_image(url=attch[0].proxy_url)
 
+    if stickers:
+      for sticker in stickers:
+        snipe_em.set_image(url=sticker.url) #sets the embed images as the stickers that was sent
+
     snipe_em.set_footer(text=f"Deleted in {channel}")
-    await ctx.send(embed=snipe_em)
+    await interaction.response.send_message(embed=snipe_em)  # Send embed with message content and author info
 
 
-@bot.command()
-async def snipeedit(ctx):  #Same concept as snipe
+@bot.tree.command(name="esnipe", description="will snipe the last message edited")
+async def snipeedit(interaction: discord.Interaction):
     try:
-        contents, author, channel, time = sniped_edit[ctx.channel.id]
+        original, author, edited, channel, time = sniped_edit[interaction.channel.id]
     except KeyError:
-        return await ctx.send("No recent edits found")
+        return await interaction.response.send_message("No recent edits found")
 
-    snipe_ed = discord.Embed(description=contents,
-                             color=discord.Color.blurple(),
-                             timestamp=time)
-    snipe_ed.set_author(name=author, icon_url=author.display_avatar.url)
-    snipe_ed.set_footer(text=f"Deleted in {channel}")
-    await ctx.send(embed=snipe_ed)
+    snipe_embed = discord.Embed(color=discord.Color.blurple(), timestamp=time)
+    snipe_embed.set_author(name=author.display_name, icon_url=author.display_avatar.url)
+    snipe_embed.set_footer(text=f"Message edited in {channel}")
 
-keep_alive()
-bot.run(TOKEN)
+    # Add fields for original and edited content
+    snipe_embed.add_field(name="Original Content", value=original, inline=False)
+    snipe_embed.add_field(name="Edited to", value=edited, inline=False)
+
+    await interaction.response.send_message(embed=snipe_embed)
+
+try:
+    keep_alive()
+    bot.run(TOKEN)
+except discord.errors.HTTPException:
+  os.system("echo RATELIMITED, TRYING AGAIN")
+  sleep(25)
+  os.system("kill 1")


### PR DESCRIPTION
- added sticker sniping capability 
- changed "mp4" sniping to send the link to the file instead 
- edit snipe will now show the old message and then what it was edited to 
- discord changed the username system and since discriminators are no longer a thing the bot will now snipe the username of the message 
- implemented slash commands for snipe and edit-snipe 
- removed the old commands to only be able to use slash commands